### PR TITLE
#11 Add Javadoc

### DIFF
--- a/src/main/java/io/github/ilyalisov/common/model/BaseEntity.java
+++ b/src/main/java/io/github/ilyalisov/common/model/BaseEntity.java
@@ -21,17 +21,48 @@ import java.time.LocalDateTime;
 import java.util.Objects;
 import java.util.UUID;
 
+/**
+ * Abstract base entity class that provides common fields and behavior for all
+ * JPA entities in the system. This class implements serializable and includes
+ * automatic ID generation, audit timestamps, and status tracking.
+ * <p>
+ * Entities extending this class will automatically have:
+ * <ul>
+ * <li>UUID primary key with automatic generation</li>
+ * <li>Creation and update timestamps</li>
+ * <li>Status field with default ACTIVE status</li>
+ * <li>Proper equals/hashCode implementation based on ID</li>
+ * <li>JSON serialization formatting for timestamps</li>
+ * </ul>
+ * </p>
+ *
+ * @author Ilya Lisov
+ * @see Serializable
+ * @see MappedSuperclass
+ * @see Status
+ * @since 0.1.0
+ */
 @MappedSuperclass
 @Getter
 @Setter
 @ToString
 public abstract class BaseEntity implements Serializable {
 
+    /**
+     * Universally unique identifier serving as the primary key for the entity.
+     * Automatically generated using UUID strategy and stored as VARCHAR in
+     * database for better compatibility across different database systems.
+     */
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     @JdbcTypeCode(SqlTypes.VARCHAR)
     protected UUID id;
 
+    /**
+     * Timestamp indicating when the entity was initially created.
+     * This field is automatically set upon entity creation and cannot be
+     * updated afterward. Formatted in ISO-like pattern for JSON serialization.
+     */
     @Column(updatable = false)
     @CreationTimestamp
     @JsonFormat(
@@ -40,6 +71,11 @@ public abstract class BaseEntity implements Serializable {
     )
     protected LocalDateTime created;
 
+    /**
+     * Timestamp indicating the last time the entity was updated.
+     * This field is automatically updated by Hibernate on each entity update.
+     * Formatted in ISO-like pattern for JSON serialization.
+     */
     @UpdateTimestamp
     @JsonFormat(
             shape = JsonFormat.Shape.STRING,
@@ -47,15 +83,33 @@ public abstract class BaseEntity implements Serializable {
     )
     protected LocalDateTime updated;
 
+    /**
+     * Current status of the entity indicating its lifecycle state.
+     * Defaults to ACTIVE upon entity creation. Stored as string in database
+     * for better readability and maintainability.
+     */
     @Enumerated(EnumType.STRING)
     protected Status status;
 
+    /**
+     * Default constructor that initializes the entity with default values.
+     * Sets status to ACTIVE and initializes timestamps to current time.
+     */
     public BaseEntity() {
         this.status = Status.ACTIVE;
         this.created = LocalDateTime.now();
         this.updated = LocalDateTime.now();
     }
 
+    /**
+     * Compares this entity with another object for equality.
+     * Two entities are considered equal if they have the same non-null ID
+     * and are of the same class. This implementation provides consistent
+     * behavior for JPA entity comparisons.
+     *
+     * @param o the object to compare with
+     * @return true if the objects are equal, false otherwise
+     */
     @Override
     public boolean equals(
             final Object o
@@ -70,6 +124,13 @@ public abstract class BaseEntity implements Serializable {
         return id.equals(that.id);
     }
 
+    /**
+     * Returns a hash code value for the entity based on its ID.
+     * This implementation ensures that entities with the same ID have
+     * the same hash code, maintaining the equals-hashCode contract.
+     *
+     * @return a hash code value for this entity
+     */
     @Override
     public int hashCode() {
         return Objects.hash(id);

--- a/src/main/java/io/github/ilyalisov/common/model/Exceptions.kt
+++ b/src/main/java/io/github/ilyalisov/common/model/Exceptions.kt
@@ -1,29 +1,99 @@
 package io.github.ilyalisov.common.model
 
+/**
+ * Exception thrown when a requested resource cannot be found in the system.
+ * This typically occurs when attempting to access, update, or delete a
+ * resource that does not exist, does not have ACTIVE status or has been
+ * removed.
+ *
+ * @param message the detailed exception message, optional
+ *
+ * @author Ilya Lisov
+ * @since 0.1.0
+ */
 class ResourceNotFoundException(
     message: String? = null
 ) : RuntimeException(message)
 
+/**
+ * Exception thrown when a user attempts to access a resource or perform an
+ * action without sufficient permissions or authentication.
+ * This exception corresponds to HTTP 403 Forbidden status.
+ *
+ * @param message the detailed exception message, optional
+ *
+ * @author Ilya Lisov
+ * @since 0.1.0
+ */
 class AccessDeniedException(
     message: String? = null
 ) : RuntimeException(message)
 
+/**
+ * Exception thrown when attempting to create a resource that already exists
+ * in the system with the same unique constraints (e.g., duplicate email,
+ * username, or other unique fields).
+ *
+ * @param message the detailed exception message, optional
+ *
+ * @author Ilya Lisov
+ * @since 0.1.0
+ */
 class ResourceAlreadyExistsException(
     message: String? = null
 ) : RuntimeException(message)
 
+/**
+ * Exception thrown when input data fails validation rules or business logic
+ * constraints. This can include format violations, range errors, or other
+ * data integrity issues.
+ *
+ * @param message the detailed exception message, optional
+ *
+ * @author Ilya Lisov
+ * @since 0.1.0
+ */
 class DataNotValidException(
     message: String? = null
 ) : RuntimeException(message)
 
+/**
+ * Exception thrown when a provided token is invalid, expired, malformed, or
+ * cannot be processed. This includes JWT tokens, activation tokens, and
+ * other authentication tokens.
+ *
+ * @param message the detailed exception message, optional
+ *
+ * @author Ilya Lisov
+ * @since 0.1.0
+ */
 class TokenNotValidException(
     message: String? = null
 ) : RuntimeException(message)
 
+/**
+ * Exception thrown when file upload operations fail due to various reasons
+ * such as storage errors, network issues, file size limits, or unsupported
+ * file formats.
+ *
+ * @param message the detailed exception message, optional
+ *
+ * @author Ilya Lisov
+ * @since 0.1.0
+ */
 class UploadException(
     message: String? = null
 ) : RuntimeException(message)
 
+/**
+ * Exception thrown when a financial transaction or operation cannot be
+ * completed due to insufficient funds or balance in the user's account.
+ *
+ * @param message the detailed exception message, optional
+ *
+ * @author Ilya Lisov
+ * @since 0.1.0
+ */
 class NotEnoughMoneyException(
     message: String? = null
 ) : RuntimeException(message)

--- a/src/main/java/io/github/ilyalisov/common/model/Status.kt
+++ b/src/main/java/io/github/ilyalisov/common/model/Status.kt
@@ -1,13 +1,63 @@
 package io.github.ilyalisov.common.model
 
+/**
+ * Enumeration representing the lifecycle states of entities in the system.
+ * Each status defines a specific state in the entity's lifecycle and is used
+ * for filtering, business logic, and access control throughout the
+ * application.
+ *
+ * @author Ilya Lisov
+ * @since 0.1.0
+ */
 enum class Status {
 
+    /**
+     * Entity is fully active and operational. This is the default state for
+     * most entities and indicates they are visible and accessible according
+     * to normal business rules.
+     */
     ACTIVE,
+
+    /**
+     * Entity is registered but not yet activated. Typically used for users
+     * who have registered but not yet completed email verification or other
+     * activation steps. Limited functionality available.
+     */
     NOT_ACTIVE,
+
+    /**
+     * Entity has been temporarily blocked from normal operations. This can
+     * be due to policy violations, security concerns, or administrative
+     * action. Entity data is preserved but access is restricted.
+     */
     BLOCKED,
+
+    /**
+     * Entity has been soft-deleted and is no longer active in the system.
+     * The data is retained for historical purposes but is excluded from
+     * normal queries and operations. Can potentially be restored.
+     */
     DELETED,
+
+    /**
+     * Entity is undergoing review by moderators or administrators before
+     * being made publicly available. Common for user-generated content
+     * that requires approval.
+     */
     UNDER_MODERATION,
+
+    /**
+     * Entity has been reviewed by moderators and rejected for publication.
+     * The entity failed to meet content guidelines or quality standards
+     * during the moderation process.
+     */
     MODERATION_DECLINED,
+
+    /**
+     * Entity is in progress and not yet ready for publication or active use.
+     * Typically used for content that is being drafted and saved for later
+     * completion or submission.
+     */
     DRAFT
 
 }

--- a/src/main/java/io/github/ilyalisov/common/model/TokenType.kt
+++ b/src/main/java/io/github/ilyalisov/common/model/TokenType.kt
@@ -1,11 +1,51 @@
 package io.github.ilyalisov.common.model
 
+/**
+ * Enumeration representing different types of tokens used throughout the
+ * application for various authentication, authorization, and business
+ * process purposes. Each token type has specific characteristics including
+ * expiration time, scope, and intended use case.
+ *
+ * @author Ilya Lisov
+ * @since 0.1.0
+ */
 enum class TokenType {
 
+    /**
+     * Short-lived token used for accessing protected resources and API
+     * endpoints. Typically, has a short expiration time (minutes to hours)
+     * and contains user authorization claims. Automatically renewed using
+     * refresh tokens when expired.
+     */
     ACCESS,
+
+    /**
+     * Long-lived token used to obtain new access tokens without requiring
+     * user re-authentication. Stored securely and has a longer expiration
+     * time (days to weeks). Can be revoked for security purposes.
+     */
     REFRESH,
+
+    /**
+     * Token used for account activation and email verification processes.
+     * Sent to users via email during registration to verify their email
+     * address and activate their account. Typically, single-use.
+     */
     ACTIVATION,
+
+    /**
+     * Token used for password reset and recovery procedures. Sent to users
+     * when they request to reset their forgotten password. Provides
+     * temporary access to password change functionality.
+     */
     PASSWORD_RESET,
+
+    /**
+     * Generic token type for custom application-specific use cases not
+     * covered by the standard token types. Can be used for various business
+     * processes like email change confirmation, two-factor authentication,
+     * or temporary access grants.
+     */
     CUSTOM
 
 }

--- a/src/main/java/io/github/ilyalisov/common/model/criteria/Criteria.java
+++ b/src/main/java/io/github/ilyalisov/common/model/criteria/Criteria.java
@@ -8,15 +8,59 @@ import org.springframework.data.domain.Sort;
 
 import java.util.Objects;
 
+/**
+ * Abstract base class for all criteria implementations used for filtering and
+ * pagination in data retrieval operations. Provides common pagination, status
+ * filtering, and search query capabilities that can be extended for specific
+ * domain requirements.
+ * <p>
+ * This class uses Lombok's {@link SuperBuilder} to provide a fluent builder
+ * pattern for creating criteria instances with sensible defaults.
+ * </p>
+ *
+ * @author Ilya Lisov
+ * @see Pageable
+ * @see Status
+ * @see SuperBuilder
+ * @since 0.1.0
+ */
 @Getter
 @SuperBuilder
 public abstract class Criteria {
 
+    /**
+     * The current page number (1-based index). Defaults to 1.
+     * Represents which page of results to retrieve.
+     */
     protected int pageId;
+
+    /**
+     * The number of items to display per page. Defaults to 10.
+     * Must be a positive integer.
+     */
     protected int perPage;
+
+    /**
+     * The status filter for entities. Defaults to {@link Status#ACTIVE}.
+     * Used to filter entities based on their status.
+     */
     protected Status status;
+
+    /**
+     * The search query string for text-based filtering.
+     * Can be used for full-text search or partial matching.
+     */
     protected String query;
 
+    /**
+     * Returns the trimmed search query string.
+     * <p>
+     * If the query is null, returns an empty string. Otherwise, returns the
+     * query with leading and trailing whitespace removed.
+     * </p>
+     *
+     * @return the trimmed query string, never null
+     */
     public String getQuery() {
         if (query != null) {
             return query.trim();
@@ -24,23 +68,52 @@ public abstract class Criteria {
         return "";
     }
 
+    /**
+     * Abstract builder class for {@link Criteria} implementations.
+     * Provides common builder methods with sensible defaults and null-safe
+     * operations.
+     *
+     * @param <C> the concrete criteria type being built
+     * @param <B> the concrete builder type
+     */
     public abstract static class CriteriaBuilder<
             C extends Criteria,
             B extends CriteriaBuilder<C, B>
             > {
 
-        protected int pageId;
-        protected int perPage;
-
+        /**
+         * Default constructor that initializes builder with sensible defaults:
+         * <ul>
+         *   <li>pageId: 1</li>
+         *   <li>perPage: 10</li>
+         *   <li>status: {@link Status#ACTIVE}</li>
+         * </ul>
+         */
         public CriteriaBuilder() {
             this.pageId = 1;
             this.perPage = 10;
             this.status = Status.ACTIVE;
         }
 
+        /**
+         * Sets the page number for pagination.
+         * <p>
+         * If the provided pageId is null, defaults to 1.
+         * Page numbers are 1-based (page 1 is the first page).
+         * </p>
+         *
+         * @param pageId the page number (1-based), can be null to use default
+         * @return the builder instance for method chaining
+         * @throws IllegalArgumentException if pageId is less than 1
+         */
         public B pageId(
                 final Integer pageId
         ) {
+            if (pageId < 1) {
+                throw new IllegalArgumentException(
+                        "pageId must be greater than 1"
+                );
+            }
             this.pageId = Objects.requireNonNullElse(
                     pageId,
                     1
@@ -48,9 +121,26 @@ public abstract class Criteria {
             return self();
         }
 
+        /**
+         * Sets the number of items per page.
+         * <p>
+         * If the provided perPage is null, defaults to 10.
+         * The value must be positive.
+         * </p>
+         *
+         * @param perPage the number of items per page, can be null to use
+         *                default
+         * @return the builder instance for method chaining
+         * @throws IllegalArgumentException if perPage is less than 1
+         */
         public B perPage(
                 final Integer perPage
         ) {
+            if (perPage < 1) {
+                throw new IllegalArgumentException(
+                        "perPage must be greater than 1"
+                );
+            }
             this.perPage = Objects.requireNonNullElse(
                     perPage,
                     10
@@ -58,6 +148,17 @@ public abstract class Criteria {
             return self();
         }
 
+        /**
+         * Sets the status filter for the criteria.
+         * <p>
+         * If the provided status is null, defaults to {@link Status#ACTIVE}.
+         * This filter is used to retrieve entities with specific status values.
+         * </p>
+         *
+         * @param status the status to filter by, can be null to use default
+         * @return the builder instance for method chaining
+         * @see Status
+         */
         public B status(
                 final Status status
         ) {
@@ -68,6 +169,16 @@ public abstract class Criteria {
             return self();
         }
 
+        /**
+         * Sets the search query string for text-based filtering.
+         * <p>
+         * The query can be used for full-text search, partial matching, or
+         * any other text-based filtering logic implemented by the repository.
+         * </p>
+         *
+         * @param query the search query string, can be null
+         * @return the builder instance for method chaining
+         */
         public B query(
                 final String query
         ) {
@@ -77,10 +188,36 @@ public abstract class Criteria {
 
     }
 
+    /**
+     * Creates a {@link Pageable} instance using the criteria's pagination
+     * settings without any specific sorting.
+     * <p>
+     * This is a convenience method that delegates to {@link #getPageable(Sort)}
+     * with a null sort parameter.
+     * </p>
+     *
+     * @return a Pageable instance configured with pageId and perPage values
+     * @see #getPageable(Sort)
+     */
     public Pageable getPageable() {
-        return getPageable(null);
+        return getPageable(Sort.unsorted());
     }
 
+    /**
+     * Creates a {@link Pageable} instance using the criteria's pagination
+     * settings and the provided sort configuration.
+     * <p>
+     * Implementing classes must provide concrete implementation to handle
+     * domain-specific sorting requirements. The method should convert the
+     * 1-based pageId to Spring Data's 0-based page number.
+     * </p>
+     *
+     * @param defaultSort the default sort to apply if no sort is specified
+     *                    in the criteria, can be null
+     * @return a Pageable instance configured with pagination and sorting
+     * @throws IllegalArgumentException if pageId is less than 1 or perPage is
+     *                                  less than 1
+     */
     public abstract Pageable getPageable(
             Sort defaultSort
     );

--- a/src/main/java/io/github/ilyalisov/common/repository/CustomPostgresSQLDialect.java
+++ b/src/main/java/io/github/ilyalisov/common/repository/CustomPostgresSQLDialect.java
@@ -4,9 +4,32 @@ import lombok.NoArgsConstructor;
 import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.dialect.PostgreSQLDialect;
 
+/**
+ * Custom PostgreSQL dialect that extends the standard Hibernate PostgreSQL
+ * dialect with additional functions and features specific to the application's
+ * needs. Currently, adds full-text search capabilities using PostgreSQL's
+ * tsvector functionality.
+ *
+ * @author Ilya Lisov
+ * @since 0.1.0
+ *
+ * @see PostgreSQLDialect
+ * @see FunctionContributions
+ */
 @NoArgsConstructor
 public class CustomPostgresSQLDialect extends PostgreSQLDialect {
 
+    /**
+     * Initializes the function registry by registering custom SQL functions
+     * in addition to the standard PostgreSQL functions. Currently, registers
+     * a custom function for full-text search using PostgreSQL's tsvector
+     * matching operator (@@).
+     *
+     * @param functionContributions the function contributions object used to
+     *        register custom functions with Hibernate
+     *
+     * @see FunctionContributions
+     */
     @Override
     public void initializeFunctionRegistry(
             final FunctionContributions functionContributions

--- a/src/main/java/io/github/ilyalisov/common/repository/specification/CommonSpec.kt
+++ b/src/main/java/io/github/ilyalisov/common/repository/specification/CommonSpec.kt
@@ -5,8 +5,28 @@ import io.github.ilyalisov.common.model.Status
 import org.springframework.data.jpa.domain.Specification
 import java.util.*
 
+/**
+ * Utility object providing common JPA Specifications for filtering entities
+ * based on status, authorship, and temporal criteria. These specifications
+ * can be combined to build complex queries in a type-safe and reusable
+ * manner.
+ *
+ * @author Ilya Lisov
+ * @since 0.1.0
+ *
+ * @see Specification
+ * @see BaseEntity
+ * @see Status
+ */
 object CommonSpec {
 
+    /**
+     * Creates a specification to filter entities by their status.
+     *
+     * @param T the type of entity extending BaseEntity
+     * @param status the status to filter by
+     * @return Specification that matches entities with the given status
+     */
     fun <T : BaseEntity> hasStatus(
         status: Status
     ): Specification<T> {
@@ -18,34 +38,91 @@ object CommonSpec {
         }
     }
 
+    /**
+     * Creates a specification to filter active entities.
+     * Equivalent to [hasStatus] with [Status.ACTIVE].
+     *
+     * @param T the type of entity extending BaseEntity
+     * @return Specification that matches active entities
+     */
     fun <T : BaseEntity> isActive(): Specification<T> {
         return hasStatus(Status.ACTIVE)
     }
 
+    /**
+     * Creates a specification to filter not active entities.
+     * Equivalent to [hasStatus] with [Status.NOT_ACTIVE].
+     *
+     * @param T the type of entity extending BaseEntity
+     * @return Specification that matches not active entities
+     */
     fun <T : BaseEntity> isNotActive(): Specification<T> {
         return hasStatus(Status.NOT_ACTIVE)
     }
 
+    /**
+     * Creates a specification to filter blocked entities.
+     * Equivalent to [hasStatus] with [Status.BLOCKED].
+     *
+     * @param T the type of entity extending BaseEntity
+     * @return Specification that matches blocked entities
+     */
     fun <T : BaseEntity> isBlocked(): Specification<T> {
         return hasStatus(Status.BLOCKED)
     }
 
+    /**
+     * Creates a specification to filter deleted entities.
+     * Equivalent to [hasStatus] with [Status.DELETED].
+     *
+     * @param T the type of entity extending BaseEntity
+     * @return Specification that matches deleted entities
+     */
     fun <T : BaseEntity> isDeleted(): Specification<T> {
         return hasStatus(Status.DELETED)
     }
 
+    /**
+     * Creates a specification to filter entities under moderation.
+     * Equivalent to [hasStatus] with [Status.UNDER_MODERATION].
+     *
+     * @param T the type of entity extending BaseEntity
+     * @return Specification that matches entities under moderation
+     */
     fun <T : BaseEntity> isUnderModeration(): Specification<T> {
         return hasStatus(Status.UNDER_MODERATION)
     }
 
+    /**
+     * Creates a specification to filter moderation declined entities.
+     * Equivalent to [hasStatus] with [Status.MODERATION_DECLINED].
+     *
+     * @param T the type of entity extending BaseEntity
+     * @return Specification that matches moderation declined entities
+     */
     fun <T : BaseEntity> isModerationDeclined(): Specification<T> {
         return hasStatus(Status.MODERATION_DECLINED)
     }
 
+    /**
+     * Creates a specification to filter draft entities.
+     * Equivalent to [hasStatus] with [Status.DRAFT].
+     *
+     * @param T the type of entity extending BaseEntity
+     * @return Specification that matches draft entities
+     */
     fun <T : BaseEntity> isDraft(): Specification<T> {
         return hasStatus(Status.DRAFT)
     }
 
+    /**
+     * Creates a specification to filter entities by their author's ID.
+     * Assumes entities have an "author" association with an "id" field.
+     *
+     * @param T the type of entity extending BaseEntity
+     * @param id the author's UUID to filter by
+     * @return Specification that matches entities with the given author ID
+     */
     fun <T : BaseEntity> hasAuthorId(
         id: UUID
     ): Specification<T> {
@@ -58,6 +135,17 @@ object CommonSpec {
         }
     }
 
+    /**
+     * Creates a specification to filter entities created within a date
+     * range. Supports open-ended ranges when either start or end date is
+     * null.
+     *
+     * @param T the type of entity extending BaseEntity
+     * @param D the type of date (must be Comparable)
+     * @param startDate the start of the date range (inclusive), can be null
+     * @param endDate the end of the date range (inclusive), can be null
+     * @return Specification that matches entities created in the period
+     */
     fun <T : BaseEntity, D : Comparable<D>> inPeriod(
         startDate: D?,
         endDate: D?
@@ -92,6 +180,16 @@ object CommonSpec {
         }
     }
 
+    /**
+     * Creates a specification combining active status and date range
+     * filtering. Convenience method for common query patterns.
+     *
+     * @param T the type of entity extending BaseEntity
+     * @param D the type of date (must be Comparable)
+     * @param start the start of the date range (inclusive), can be null
+     * @param end the end of the date range (inclusive), can be null
+     * @return Specification that matches active entities in the period
+     */
     fun <T : BaseEntity, D : Comparable<D>> activeInPeriod(
         start: D?,
         end: D?

--- a/src/main/java/io/github/ilyalisov/common/repository/specification/SpecificationUtils.java
+++ b/src/main/java/io/github/ilyalisov/common/repository/specification/SpecificationUtils.java
@@ -4,8 +4,32 @@ import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.JoinType;
 import jakarta.persistence.criteria.Root;
 
+/**
+ * Utility class providing helper methods for working with JPA Specifications
+ * and Criteria API. Contains reusable functionality for managing joins and
+ * other specification-related operations.
+ *
+ * @author Ilya Lisov
+ * @since 0.1.0
+ */
 public class SpecificationUtils {
 
+    /**
+     * Retrieves an existing join or creates a new one if it doesn't exist.
+     * This method prevents duplicate joins in criteria queries by checking
+     * for existing joins with the same attribute and join type before
+     * creating a new one.
+     *
+     * @param <T1>      the source entity type
+     * @param <T2>      the target entity type to join with
+     * @param root      the root entity in the criteria query
+     * @param attribute the name of the attribute to join on
+     * @param joinType  the type of join to perform (INNER, LEFT, RIGHT, etc.)
+     * @return an existing join if found, or a new join if not present
+     * @throws IllegalArgumentException if the attribute does not exist on
+     *                                  the root entity or if the join cannot
+     *                                  be created
+     */
     public static <T1, T2> Join<T1, T2> getJoin(
             final Root<T1> root,
             final String attribute,

--- a/src/main/java/io/github/ilyalisov/common/service/Blockable.kt
+++ b/src/main/java/io/github/ilyalisov/common/service/Blockable.kt
@@ -2,12 +2,43 @@ package io.github.ilyalisov.common.service
 
 import java.util.*
 
+/**
+ * Interface defining operations for entities that can be blocked and
+ * unblocked. Implementing this interface provides a standardized way to
+ * manage the blocking state of entities such as users, posts, comments,
+ * or other domain objects that require temporary suspension of access or
+ * functionality.
+ *
+ * @author Ilya Lisov
+ * @since 0.1.0
+ */
 interface Blockable {
 
+    /**
+     * Blocks the entity with the specified ID, effectively suspending its
+     * normal operations and access. The implementation should typically
+     * update the entity's status to
+     * [io.github.ilyalisov.common.model.Status.BLOCKED]
+     * and apply any additional business logic required for blocking.
+     *
+     * @param id the UUID of the entity to be blocked
+     * @throws io.github.ilyalisov.common.model.ResourceNotFoundException if
+     * no entity with the given ID exists
+     */
     fun block(
         id: UUID
     )
 
+    /**
+     * Unblocks the entity with the specified ID, restoring its normal
+     * operations and access. The implementation should typically update
+     * the entity's status to [io.github.ilyalisov.common.model.Status.ACTIVE]
+     * and remove any blocking-related restrictions.
+     *
+     * @param id the UUID of the entity to be unblocked
+     * @throws io.github.ilyalisov.common.model.ResourceNotFoundException if
+     * no entity with the given ID exists
+     */
     fun unblock(
         id: UUID
     )

--- a/src/main/java/io/github/ilyalisov/common/service/CrudService.java
+++ b/src/main/java/io/github/ilyalisov/common/service/CrudService.java
@@ -6,40 +6,133 @@ import org.springframework.data.domain.Page;
 
 import java.util.UUID;
 
+/**
+ * Generic CRUD service interface providing common create, read, update, and
+ * delete operations for entities. This interface serves as a foundation for
+ * service layers across different domain entities, ensuring consistent
+ * behavior and reducing boilerplate code.
+ *
+ * @param <T> the entity type extending BaseEntity
+ * @param <C> the criteria type used for filtering and pagination
+ * @author Ilya Lisov
+ * @see BaseEntity
+ * @see Criteria
+ * @since 0.1.0
+ */
 public interface CrudService<T extends BaseEntity, C extends Criteria> {
 
+    /**
+     * Retrieves an entity by its ID. This default implementation delegates
+     * to the overloaded method with safe mode set to false, meaning it will
+     * throw an exception if the entity is not found or not accessible.
+     *
+     * @param id the UUID of the entity to retrieve
+     * @return the found entity
+     * @throws io.github.ilyalisov.common.model.ResourceNotFoundException if
+     * the entity is not found or not accessible with normal visibility rules
+     */
     default T getById(
             final UUID id
     ) {
         return getById(id, false);
     }
 
+    /**
+     * Retrieves an entity by its ID with optional safe mode. When safe mode
+     * is disabled, enforces normal visibility rules (e.g., only active
+     * entities). When safe mode is enabled, may return entities regardless
+     * of their status or visibility.
+     *
+     * @param id         the UUID of the entity to retrieve
+     * @param showAnyway if true, bypasses normal visibility rules and
+     *                   status filters
+     * @return the found entity
+     * @throws io.github.ilyalisov.common.model.ResourceNotFoundException if
+     * the entity is not found
+     */
     T getById(
             UUID id,
             boolean showAnyway
     );
 
+    /**
+     * Retrieves a paginated list of entities matching the provided criteria.
+     * The criteria includes pagination parameters, status filters, search
+     * queries, and other domain-specific filtering options.
+     *
+     * @param criteria the filtering and pagination criteria
+     * @return a page of entities matching the criteria
+     */
     Page<T> getAll(
             C criteria
     );
 
+    /**
+     * Retrieves a paginated list of entities created by a specific author
+     * and matching the provided criteria. Useful for user-specific data
+     * views and personal dashboards.
+     *
+     * @param authorId the UUID of the author to filter by
+     * @param criteria the filtering and pagination criteria
+     * @return a page of entities by the author matching the criteria
+     */
     Page<T> getAllByAuthorId(
             UUID authorId,
             C criteria
     );
 
+    /**
+     * Counts the number of entities matching the provided criteria. This
+     * method is optimized for counting without loading actual entity data,
+     * making it efficient for statistics and pagination metadata.
+     *
+     * @param criteria the filtering criteria
+     * @return the total count of entities matching the criteria
+     */
     long countAll(
             C criteria
     );
 
+    /**
+     * Creates a new entity from the provided data. Validates the input,
+     * applies business rules, and persists the entity to the database.
+     *
+     * @param dto the entity data to create
+     * @return the created entity with generated fields (ID, timestamps)
+     * @throws io.github.ilyalisov.common.model.ResourceAlreadyExistsException
+     * if an entity with conflicting unique constraints exists
+     * @throws io.github.ilyalisov.common.model.DataNotValidException if the
+     * input data fails validation
+     */
     T create(
             T dto
     );
 
+    /**
+     * Updates an existing entity with the provided data. The entity must
+     * exist and be accessible. Only modifiable fields are updated while
+     * preserving audit fields and immutable properties.
+     *
+     * @param dto the entity data to update
+     * @return the updated entity
+     * @throws io.github.ilyalisov.common.model.ResourceNotFoundException if
+     * the entity to update is not found
+     * @throws io.github.ilyalisov.common.model.DataNotValidException if the
+     * input data fails validation
+     */
     T update(
             T dto
     );
 
+    /**
+     * Deletes an entity by its ID. Typically, implements soft delete by
+     * updating the entity's status to DELETED rather than physical removal
+     * from the database, preserving data integrity and audit history.
+     *
+     * @param id the UUID of the entity to delete
+     * @throws io.github.ilyalisov.common.model.ResourceNotFoundException if
+     * the entity to delete is not found
+     */
     void delete(
             UUID id
     );

--- a/src/main/java/io/github/ilyalisov/common/service/Moderatable.kt
+++ b/src/main/java/io/github/ilyalisov/common/service/Moderatable.kt
@@ -2,12 +2,47 @@ package io.github.ilyalisov.common.service
 
 import java.util.*
 
+/**
+ * Interface defining operations for entities that require moderation
+ * workflows. Extends [Blockable] to provide comprehensive content
+ * management capabilities including approval, rejection, and blocking
+ * functionality.
+ *
+ * Entities implementing this interface typically represent user-generated
+ * content that requires review before publication, such as posts, comments,
+ * reviews, or other community content.
+ *
+ * @author Ilya Lisov
+ * @since 0.1.0
+ *
+ * @see Blockable
+ */
 interface Moderatable : Blockable {
 
+    /**
+     * Approves the entity with the specified ID, allowing it to be publicly
+     * visible and accessible. This method typically updates the entity's
+     * status to [io.github.ilyalisov.common.model.Status.ACTIVE] and may
+     * trigger additional business logic such as notifications or indexing.
+     *
+     * @param id the UUID of the entity to be approved
+     * @throws io.github.ilyalisov.common.model.ResourceNotFoundException if
+     * no entity with the given ID exists
+     */
     fun allow(
         id: UUID
     )
 
+    /**
+     * Rejects the entity with the specified ID, preventing it from being
+     * publicly visible. This method typically updates the entity's status
+     * to [io.github.ilyalisov.common.model.Status.MODERATION_DECLINED] and
+     * may include reasons for rejection or additional moderation notes.
+     *
+     * @param id the UUID of the entity to be rejected
+     * @throws io.github.ilyalisov.common.model.ResourceNotFoundException if
+     * no entity with the given ID exists
+     */
     fun disallow(
         id: UUID
     )

--- a/src/main/java/io/github/ilyalisov/common/web/dto/MessageDto.kt
+++ b/src/main/java/io/github/ilyalisov/common/web/dto/MessageDto.kt
@@ -1,8 +1,27 @@
 package io.github.ilyalisov.common.web.dto
 
+/**
+ * Data transfer object for standardized API response messages with optional
+ * error details. This class provides a consistent structure for both success
+ * messages and validation error responses throughout the application.
+ *
+ * @param message the main message describing the result or error
+ * @param errors a map of field-specific error messages, where keys represent
+ *        field names and values contain error descriptions
+ *
+ * @author Ilya Lisov
+ * @since 0.1.0
+ */
 data class MessageDto(
     val message: String,
     val errors: Map<String, String>
 ) {
+    /**
+     * Secondary constructor for creating a MessageDto with only a main message
+     * and no field-specific errors. Useful for simple success messages or
+     * general error notifications without detailed field validation.
+     *
+     * @param message the main message describing the result or error
+     */
     constructor(message: String) : this(message, emptyMap())
 }

--- a/src/main/java/io/github/ilyalisov/common/web/dto/ValidationScopes.kt
+++ b/src/main/java/io/github/ilyalisov/common/web/dto/ValidationScopes.kt
@@ -1,11 +1,86 @@
 package io.github.ilyalisov.common.web.dto
 
+/**
+ * Validation group interface for scenarios where entity validation is
+ * required specifically during publishing operations. Use this group to
+ * define constraints that should only be checked when an entity is being
+ * published or made publicly available.
+ *
+ * @author Ilya Lisov
+ * @since 0.1.0
+ *
+ * @example
+ * ```
+ * @NotBlank(groups = [OnPublish::class])
+ * val content: String
+ * ```
+ */
 interface OnPublish
 
+/**
+ * Validation group interface for scenarios where entity validation is
+ * required specifically during update operations. Use this group to define
+ * constraints that should only be checked when updating existing entities,
+ * allowing different validation rules than during creation.
+ *
+ * @author Ilya Lisov
+ * @since 0.1.0
+ *
+ * @example
+ * ```
+ * @NotNull(groups = [OnUpdate::class])
+ * val version: Long
+ * ```
+ */
 interface OnUpdate
 
+/**
+ * Validation group interface for scenarios where entity validation is
+ * required specifically during creation operations. Use this group to
+ * define constraints that should only be checked when creating new entities,
+ * allowing different validation rules than during updates.
+ *
+ * @author Ilya Lisov
+ * @since 0.1.0
+ *
+ * @example
+ * ```
+ * @NotBlank(groups = [OnCreate::class])
+ * val initialPassword: String
+ * ```
+ */
 interface OnCreate
 
+/**
+ * Validation group interface for scenarios involving nested object
+ * identification. Use this group to validate that nested objects or
+ * references to contain valid identifiers when required by the business logic.
+ *
+ * @author Ilya Lisov
+ * @since 0.1.0
+ *
+ * @example
+ * ```
+ * @Valid(groups = [NestedObjectId::class])
+ * val author: UserReference
+ * ```
+ */
 interface NestedObjectId
 
+/**
+ * Validation group interface for flexible ID validation scenarios. Use this
+ * group when an ID field should be validated regardless of whether it's
+ * provided (for updates) or not provided (for creations), allowing for
+ * conditional ID presence validation.
+ *
+ * @author Ilya Lisov
+ * @since 0.1.0
+ *
+ * @example
+ * ```
+ * @Null(groups = [OnCreate::class])
+ * @NotNull(groups = [OnUpdate::class])
+ * val id: Long?
+ * ```
+ */
 interface OnAnyId

--- a/src/main/java/io/github/ilyalisov/common/web/dto/mapper/BaseMappable.kt
+++ b/src/main/java/io/github/ilyalisov/common/web/dto/mapper/BaseMappable.kt
@@ -3,8 +3,33 @@ package io.github.ilyalisov.common.web.dto.mapper
 import io.github.ilyalisov.common.model.BaseEntity
 import org.mapstruct.Mapping
 
+/**
+ * Enhanced mapper interface that extends [Mappable] with specific
+ * ignore rules for BaseEntity audit fields. This interface ensures that
+ * status and timestamp fields are not overwritten during DTO to entity
+ * mapping, preserving important audit information.
+ *
+ * @param E the entity type extending BaseEntity
+ * @param D the DTO type used for data transfer
+ *
+ * @author Ilya Lisov
+ * @since 0.1.0
+ *
+ * @see Mappable
+ * @see BaseEntity
+ */
 interface BaseMappable<E : BaseEntity, D> : Mappable<E, D> {
 
+    /**
+     * Converts a DTO to an entity while ignoring audit fields that should
+     * not be modified from DTO data. Specifically ignores:
+     * - status (to preserve entity lifecycle state)
+     * - created (to maintain creation timestamp integrity)
+     * - updated (to allow automatic timestamp updates)
+     *
+     * @param dto the DTO object to convert
+     * @return the entity with DTO data mapped, excluding audit fields
+     */
     @Mapping(target = "status", ignore = true)
     @Mapping(target = "created", ignore = true)
     @Mapping(target = "updated", ignore = true)

--- a/src/main/java/io/github/ilyalisov/common/web/dto/mapper/Mappable.kt
+++ b/src/main/java/io/github/ilyalisov/common/web/dto/mapper/Mappable.kt
@@ -1,13 +1,55 @@
 package io.github.ilyalisov.common.web.dto.mapper
 
+/**
+ * Generic mapper interface for bidirectional conversion between entities and
+ * DTOs (Data Transfer Objects). Provides methods for both single object and
+ * collection transformations, ensuring consistent mapping patterns across
+ * the application.
+ *
+ * @param E the entity type used for business logic and persistence
+ * @param D the DTO type used for data transfer and API responses
+ *
+ * @author Ilya Lisov
+ * @since 0.1.0
+ *
+ * @see BaseMappable
+ */
 interface Mappable<E, D> {
 
+    /**
+     * Converts a single DTO object to its corresponding entity.
+     * Typically used when creating or updating entities from API input.
+     *
+     * @param dto the DTO object to convert
+     * @return the converted entity
+     */
     fun toEntity(dto: D): E
 
+    /**
+     * Converts a list of DTO objects to a list of entities.
+     * Useful for batch operations and collection transformations.
+     *
+     * @param dto the list of DTO objects to convert
+     * @return the list of converted entities
+     */
     fun toEntity(dto: List<D>): List<E>
 
+    /**
+     * Converts a single entity to its corresponding DTO.
+     * Typically used when returning entity data in API responses.
+     *
+     * @param entity the entity object to convert
+     * @return the converted DTO
+     */
     fun toDto(entity: E): D
 
+    /**
+     * Converts a list of entities to a list of DTOs.
+     * Useful for returning collections of data in API responses.
+     *
+     * @param entity the list of entity objects to convert
+     * @return the list of converted DTOs
+     */
     fun toDto(entity: List<E>): List<D>
 
 }

--- a/suppressions.xml
+++ b/suppressions.xml
@@ -15,4 +15,5 @@
     <suppress checks="RegexpSingleline"/>
     <suppress checks="MemberName"/>
     <suppress checks="MethodName"/>
+    <suppress checks="JavadocStyle"/>
 </suppressions>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces enhancements to various classes and interfaces, adding detailed documentation and new functionalities, particularly focusing on data transfer objects, specifications for entity filtering, and exception handling.

### Detailed summary
- Added `JavadocStyle` suppression in `suppressions.xml`.
- Enhanced `MessageDto` with detailed documentation and a secondary constructor.
- Documented `CustomPostgresSQLDialect` with additional functionality.
- Improved `BaseMappable` and `Mappable` interfaces with comprehensive comments.
- Created utility methods in `SpecificationUtils` for JPA specifications.
- Defined `Blockable` and `Moderatable` interfaces with methods for managing entity states.
- Expanded `TokenType` and `Status` enums with detailed descriptions.
- Introduced validation scopes in `ValidationScopes.kt`.
- Implemented multiple exception classes for error handling.
- Enhanced `BaseEntity` with detailed documentation on lifecycle management.
- Updated `CrudService` interface with comprehensive CRUD operation methods.
- Added utility specifications in `CommonSpec` for filtering entities.
- Developed an abstract `Criteria` class for pagination and filtering capabilities.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->