### PR TITLE
#31 Implement SpecBuilder, remove toSpec from Criteria

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Add to your `pom.xml`:
 <dependency>
     <groupId>io.github.ilyalisov</groupId>
     <artifactId>spring-boot-common</artifactId>
-    <version>0.1.2</version>
+    <version>0.1.3</version>
 </dependency>
 ```
 
@@ -68,7 +68,7 @@ Add to your `pom.xml`:
 Add to your `build.gradle` or `build.gradle.kts`:
 
 ```groovy
-implementation("io.github.ilyalisov:spring-boot-common:0.1.2")
+implementation("io.github.ilyalisov:spring-boot-common:0.1.3")
 ```
 
 ## Core Components
@@ -124,10 +124,6 @@ public class UserCriteria extends Criteria {
     // ... your custom fields
 }
 ```
-
-You need to implement `toSpec` method that provides `Specification`
-corresponding to criteria. It allows you to use one method instead of
-manually creating a specification.
 
 ### JWT & Security
 

--- a/src/main/java/io/github/ilyalisov/common/model/criteria/Criteria.java
+++ b/src/main/java/io/github/ilyalisov/common/model/criteria/Criteria.java
@@ -5,7 +5,6 @@ import lombok.Getter;
 import lombok.experimental.SuperBuilder;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.jpa.domain.Specification;
 
 import java.util.Objects;
 import java.util.UUID;
@@ -279,29 +278,6 @@ public abstract class Criteria {
      */
     public abstract Pageable getPageable(
             Sort defaultSort
-    );
-
-    /**
-     * Converts this criteria instance into a JPA {@link Specification} for the
-     * given entity class.
-     * <p>
-     * This method transforms the filtering criteria (status, authorId, query,
-     * etc.) into a type-safe JPA Specification that can be used with Spring
-     * Data JPA repositories. Implementing classes should provide concrete
-     * implementations that handle domain-specific filtering logic.
-     * </p>
-     *
-     * @param <T>   the type of entity for which the specification is created
-     * @param clazz the class object representing the entity type,
-     *              must not be null
-     * @return a {@link Specification} instance that encapsulates all filtering
-     * conditions defined in this criteria
-     * @throws IllegalArgumentException      if entityClass is null
-     * @throws UnsupportedOperationException if not overridden in child class
-     * @see Specification
-     */
-    public abstract <T> Specification<T> toSpec(
-            Class<T> clazz
     );
 
 }

--- a/src/main/java/io/github/ilyalisov/common/repository/specification/SpecBuilder.java
+++ b/src/main/java/io/github/ilyalisov/common/repository/specification/SpecBuilder.java
@@ -1,0 +1,61 @@
+package io.github.ilyalisov.common.repository.specification;
+
+import io.github.ilyalisov.common.model.criteria.Criteria;
+import org.springframework.data.jpa.domain.Specification;
+
+/**
+ * Strategy interface for building JPA {@link Specification} instances based on
+ * a given {@link Criteria} object.
+ * <p>
+ * Implementations of this interface are responsible for translating the
+ * filtering parameters encapsulated in a {@code Criteria} instance into a
+ * type-safe JPA {@link Specification} that can be used with Spring Data JPA
+ * repositories.
+ * </p>
+ * <p>
+ * This abstraction allows decoupling criteria objects from a specific
+ * persistence implementation, enabling:
+ * <ul>
+ *   <li>Reuse of the same {@link Criteria} across different persistence
+ *       strategies</li>
+ *   <li>Multiple {@link Specification} implementations for the same
+ *   criteria</li>
+ *   <li>Cleaner separation of concerns between filtering logic and data
+ *   access</li>
+ * </ul>
+ * </p>
+ *
+ * @param <T> the type of the JPA entity for which the specification is built
+ * @author Ilya Lisov
+ * @see Criteria
+ * @see Specification
+ * @since 0.1.3
+ */
+public interface SpecBuilder<T> {
+
+    /**
+     * Builds a JPA {@link Specification} based on the provided
+     * {@link Criteria}.
+     * <p>
+     * The implementation should interpret the values contained in the given
+     * criteria instance (such as status, author identifier, search query, or
+     * other domain-specific parameters) and compose a corresponding
+     * {@link Specification}.
+     * </p>
+     * <p>
+     * Implementations should be null-safe and may return {@code null} if the
+     * criteria does not define any filtering constraints, in accordance with
+     * Spring Data JPA's {@link Specification} composition semantics.
+     * </p>
+     *
+     * @param criteria the criteria object containing filtering parameters,
+     *                 must not be {@code null}
+     * @return a {@link Specification} representing all filtering conditions
+     * defined by the given criteria, or {@code null} if no constraints
+     * are applicable
+     */
+    Specification<T> build(
+            Criteria criteria
+    );
+
+}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the version of the `spring-boot-common` library and refactoring the criteria handling by removing the `toSpec` method from the `Criteria` class and introducing a new `SpecBuilder` interface to build JPA `Specification` instances.

### Detailed summary
- Updated version from `0.1.2` to `0.1.3` in `README.md`.
- Updated dependency version in the `implementation` line.
- Removed the `toSpec` method and its Javadoc comments from the `Criteria` class.
- Added a new `SpecBuilder` interface for creating JPA `Specification` instances based on `Criteria`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->